### PR TITLE
Feature/row49382 enable async

### DIFF
--- a/src/main/java/com/row49382/config/AsyncConfig.java
+++ b/src/main/java/com/row49382/config/AsyncConfig.java
@@ -1,0 +1,22 @@
+package com.row49382.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    @Bean
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
+        threadPoolTaskExecutor.initialize();
+        return threadPoolTaskExecutor;
+    }
+}

--- a/src/main/java/com/row49382/config/BeanConfig.java
+++ b/src/main/java/com/row49382/config/BeanConfig.java
@@ -1,13 +1,45 @@
 package com.row49382.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.row49382.domain.dto.github.response.GithubUserAggregatedResponse;
+import com.row49382.domain.third_party.github.dto.GithubUserRepoResponse;
+import com.row49382.domain.third_party.github.dto.GithubUserResponse;
+import com.row49382.mapper.BiMapper;
+import com.row49382.service.AsyncHandler;
+import com.row49382.service.GithubUserApiService;
+import com.row49382.service.JsonService;
+import com.row49382.service.impl.GitHubUserHttpClientRequestFactory;
+import com.row49382.service.impl.async.AsyncCachingGithubUserService;
+import com.row49382.service.impl.CachingGithubUserApiService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 import java.net.http.HttpClient;
+import java.util.List;
 
 @Configuration
 public class BeanConfig {
+    @Value("${handle-async:false}")
+    private boolean handleAsync;
+
+    private final JsonService jsonService;
+    private final BiMapper<GithubUserResponse, List<GithubUserRepoResponse>, GithubUserAggregatedResponse> responseMapper;
+    private final AsyncHandler<String> asyncHandler;
+    private final GitHubUserHttpClientRequestFactory requestFactory;
+
+    public BeanConfig(
+            @Lazy JsonService jsonService,
+            @Lazy BiMapper<GithubUserResponse, List<GithubUserRepoResponse>, GithubUserAggregatedResponse> responseMapper,
+            @Lazy AsyncHandler<String> asyncHandler,
+            @Lazy GitHubUserHttpClientRequestFactory requestFactory) {
+        this.jsonService = jsonService;
+        this.responseMapper = responseMapper;
+        this.asyncHandler = asyncHandler;
+        this.requestFactory = requestFactory;
+    }
+
     @Bean
     public HttpClient httpClient() {
         return HttpClient.newHttpClient();
@@ -16,5 +48,16 @@ public class BeanConfig {
     @Bean
     public ObjectMapper objectMapper() {
         return new ObjectMapper();
+    }
+
+    @Bean
+    public GithubUserApiService githubUserApiService() {
+        if (this.handleAsync) {
+            return new AsyncCachingGithubUserService(
+                    this.httpClient(), this.jsonService, this.responseMapper, this.requestFactory, this.asyncHandler);
+        }
+
+        return new CachingGithubUserApiService(
+                this.httpClient(), this.jsonService, this.responseMapper, this.requestFactory);
     }
 }

--- a/src/main/java/com/row49382/controller/GithubUserController.java
+++ b/src/main/java/com/row49382/controller/GithubUserController.java
@@ -2,8 +2,6 @@ package com.row49382.controller;
 
 import com.row49382.domain.dto.github.request.GithubUserParameters;
 import com.row49382.domain.dto.github.response.GithubUserAggregatedResponse;
-import com.row49382.exception.GithubUserFetchException;
-import com.row49382.exception.JsonDeserializationException;
 import com.row49382.service.GithubUserApiService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/row49382/controller/GithubUserController.java
+++ b/src/main/java/com/row49382/controller/GithubUserController.java
@@ -22,7 +22,7 @@ public class GithubUserController {
 
     @GetMapping
     public ResponseEntity<GithubUserAggregatedResponse> getGithubUser(@Valid GithubUserParameters params)
-            throws GithubUserFetchException, JsonDeserializationException {
+            throws Throwable {
         return ResponseEntity.ofNullable(
                 this.githubUserApiService.fetchByUsername(params.getUsername()));
     }

--- a/src/main/java/com/row49382/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/row49382/controller/GlobalExceptionHandler.java
@@ -35,9 +35,9 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(GithubUserFetchException.class)
-    @ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Unable to fetch github user")
+    @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR, reason = "Unable to fetch github user")
     public ResponseEntity<ErrorResponse> handleGithubUserFetchFailure(GithubUserFetchException ex) {
         return ResponseEntity.ofNullable(
-                new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage()));
+                new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage()));
     }
 }

--- a/src/main/java/com/row49382/exception/GithubUserFetchException.java
+++ b/src/main/java/com/row49382/exception/GithubUserFetchException.java
@@ -2,7 +2,7 @@ package com.row49382.exception;
 
 import java.io.Serial;
 
-public class GithubUserFetchException extends Exception {
+public class GithubUserFetchException extends RuntimeException {
     @Serial
     private static final long serialVersionUID = -278156538044821175L;
 

--- a/src/main/java/com/row49382/exception/JsonDeserializationException.java
+++ b/src/main/java/com/row49382/exception/JsonDeserializationException.java
@@ -2,7 +2,7 @@ package com.row49382.exception;
 
 import java.io.Serial;
 
-public class JsonDeserializationException extends Exception {
+public class JsonDeserializationException extends RuntimeException {
     @Serial
     private static final long serialVersionUID = -8600953961212069671L;
 

--- a/src/main/java/com/row49382/service/AbstractGithubUserApiService.java
+++ b/src/main/java/com/row49382/service/AbstractGithubUserApiService.java
@@ -1,0 +1,53 @@
+package com.row49382.service;
+
+import com.row49382.domain.dto.github.response.GithubUserAggregatedResponse;
+import com.row49382.domain.third_party.github.dto.GithubUserRepoResponse;
+import com.row49382.domain.third_party.github.dto.GithubUserResponse;
+import com.row49382.exception.GithubUserFetchException;
+import com.row49382.mapper.BiMapper;
+import com.row49382.service.impl.GitHubUserHttpClientRequestFactory;
+import org.springframework.boot.autoconfigure.info.ProjectInfoProperties;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+public abstract class AbstractGithubUserApiService implements GithubUserApiService {
+    protected static final String GITHUB_USER_ENDPOINT_TEMPLATE = "/users/%s";
+    protected static final String GITHUB_USER_REPO_ENDPOINT_TEMPLATE = GITHUB_USER_ENDPOINT_TEMPLATE + "/repos";
+    protected static final String GITHUB_USER_FETCH_ERROR_TEMPLATE = "Failed to fetch user information with request %s";
+
+    protected final HttpClient client;
+    protected final JsonService jsonService;
+    protected final BiMapper<GithubUserResponse, List<GithubUserRepoResponse>, GithubUserAggregatedResponse> responseMapper;
+    protected final GitHubUserHttpClientRequestFactory requestFactory;
+
+    protected AbstractGithubUserApiService(
+            HttpClient client,
+            JsonService jsonService,
+            BiMapper<GithubUserResponse, List<GithubUserRepoResponse>, GithubUserAggregatedResponse> responseMapper,
+            GitHubUserHttpClientRequestFactory requestFactory) {
+        this.client = client;
+        this.jsonService = jsonService;
+        this.responseMapper = responseMapper;
+        this.requestFactory = requestFactory;
+    }
+
+    protected HttpResponse<String> tryClientCall(HttpRequest request) {
+        try {
+            HttpResponse<String> response = this.client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                throw new GithubUserFetchException(GITHUB_USER_FETCH_ERROR_TEMPLATE.formatted(request));
+            }
+
+            return response;
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new GithubUserFetchException(GITHUB_USER_FETCH_ERROR_TEMPLATE.formatted(request), ie);
+        } catch (IOException ioe) {
+            throw new GithubUserFetchException(GITHUB_USER_FETCH_ERROR_TEMPLATE.formatted(request), ioe);
+        }
+    }
+}

--- a/src/main/java/com/row49382/service/AbstractGithubUserApiService.java
+++ b/src/main/java/com/row49382/service/AbstractGithubUserApiService.java
@@ -6,7 +6,6 @@ import com.row49382.domain.third_party.github.dto.GithubUserResponse;
 import com.row49382.exception.GithubUserFetchException;
 import com.row49382.mapper.BiMapper;
 import com.row49382.service.impl.GitHubUserHttpClientRequestFactory;
-import org.springframework.boot.autoconfigure.info.ProjectInfoProperties;
 
 import java.io.IOException;
 import java.net.http.HttpClient;

--- a/src/main/java/com/row49382/service/AsyncHandler.java
+++ b/src/main/java/com/row49382/service/AsyncHandler.java
@@ -1,0 +1,9 @@
+package com.row49382.service;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import java.util.concurrent.CompletableFuture;
+
+public interface AsyncHandler<T> {
+    CompletableFuture<HttpResponse<T>> handle(String endpoint);
+}

--- a/src/main/java/com/row49382/service/AsyncHandler.java
+++ b/src/main/java/com/row49382/service/AsyncHandler.java
@@ -1,6 +1,5 @@
 package com.row49382.service;
 
-import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import java.util.concurrent.CompletableFuture;
 

--- a/src/main/java/com/row49382/service/GithubUserApiService.java
+++ b/src/main/java/com/row49382/service/GithubUserApiService.java
@@ -1,8 +1,6 @@
 package com.row49382.service;
 
 import com.row49382.domain.dto.github.response.GithubUserAggregatedResponse;
-import com.row49382.exception.GithubUserFetchException;
-import com.row49382.exception.JsonDeserializationException;
 
 public interface GithubUserApiService {
     GithubUserAggregatedResponse fetchByUsername(String username) throws Throwable;

--- a/src/main/java/com/row49382/service/GithubUserApiService.java
+++ b/src/main/java/com/row49382/service/GithubUserApiService.java
@@ -5,5 +5,5 @@ import com.row49382.exception.GithubUserFetchException;
 import com.row49382.exception.JsonDeserializationException;
 
 public interface GithubUserApiService {
-    GithubUserAggregatedResponse fetchByUsername(String username) throws GithubUserFetchException, JsonDeserializationException;
+    GithubUserAggregatedResponse fetchByUsername(String username) throws Throwable;
 }

--- a/src/main/java/com/row49382/service/impl/GitHubUserHttpClientRequestFactory.java
+++ b/src/main/java/com/row49382/service/impl/GitHubUserHttpClientRequestFactory.java
@@ -1,0 +1,26 @@
+package com.row49382.service.impl;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+
+@Component
+public class GitHubUserHttpClientRequestFactory {
+    @Value("${github-api-url}")
+    private String githubUrl;
+
+    @Value("${github-user-agent}")
+    private String githubUserAgent;
+
+    public HttpRequest buildRequest(String endpoint) {
+        return HttpRequest.newBuilder()
+                    .uri(URI.create(githubUrl + endpoint))
+                    .header("User-Agent", githubUserAgent)
+                    .header("Accept", "application/vnd.github+json")
+                    .header("X-Github-Api-Version", "2022-11-28")
+                    .GET()
+                    .build();
+    }
+}

--- a/src/main/java/com/row49382/service/impl/async/AsyncCachingGithubUserService.java
+++ b/src/main/java/com/row49382/service/impl/async/AsyncCachingGithubUserService.java
@@ -60,7 +60,7 @@ public class AsyncCachingGithubUserService extends AbstractGithubUserApiService 
             throw new GithubUserFetchException("failed to resolve async calls in time", e);
         } catch (ExecutionException e) {
             if (e.getCause() != null) {
-                throw new Exception(e.getCause());
+                throw e.getCause();
             }
 
             throw e;

--- a/src/main/java/com/row49382/service/impl/async/AsyncCachingGithubUserService.java
+++ b/src/main/java/com/row49382/service/impl/async/AsyncCachingGithubUserService.java
@@ -1,0 +1,76 @@
+package com.row49382.service.impl.async;
+
+import com.row49382.config.CacheConfig;
+import com.row49382.domain.dto.github.response.GithubUserAggregatedResponse;
+import com.row49382.domain.third_party.github.dto.GithubUserRepoResponse;
+import com.row49382.domain.third_party.github.dto.GithubUserResponse;
+import com.row49382.exception.GithubUserFetchException;
+import com.row49382.exception.JsonDeserializationException;
+import com.row49382.mapper.BiMapper;
+import com.row49382.service.AbstractGithubUserApiService;
+import com.row49382.service.AsyncHandler;
+import com.row49382.service.JsonService;
+import com.row49382.service.impl.GitHubUserHttpClientRequestFactory;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+@Service
+public class AsyncCachingGithubUserService extends AbstractGithubUserApiService {
+    private final AsyncHandler<String> asyncHandler;
+
+    public AsyncCachingGithubUserService(
+            HttpClient client,
+            JsonService jsonService,
+            BiMapper<GithubUserResponse, List<GithubUserRepoResponse>, GithubUserAggregatedResponse> responseMapper,
+            GitHubUserHttpClientRequestFactory requestFactory,
+            AsyncHandler<String> asyncHandler) {
+        super(client, jsonService, responseMapper, requestFactory);
+        this.asyncHandler = asyncHandler;
+    }
+
+    @Override
+    @Cacheable(value = CacheConfig.GITHUB_USER_CACHE)
+    public GithubUserAggregatedResponse fetchByUsername(String username) throws Throwable {
+        CompletableFuture<HttpResponse<String>> userResponse =
+                this.asyncHandler.handle(GITHUB_USER_ENDPOINT_TEMPLATE.formatted(username));
+        CompletableFuture<HttpResponse<String>> userRepoResponses =
+                this.asyncHandler.handle(GITHUB_USER_REPO_ENDPOINT_TEMPLATE.formatted(username));
+
+        try {
+            return userResponse
+                    .thenCompose(ur -> userRepoResponses
+                            .thenApply(urr -> {
+                                this.verifySuccessfulResponse(ur);
+                                this.verifySuccessfulResponse(urr);
+
+                                GithubUserResponse githubUserResponse =
+                                        this.jsonService.deserialize(ur.body(), GithubUserResponse.class);
+                                List<GithubUserRepoResponse> githubUserRepoResponse =
+                                        this.jsonService.deserializeList(urr.body(), GithubUserRepoResponse.class);
+
+                                return this.responseMapper.map(githubUserResponse, githubUserRepoResponse);
+                            })).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new GithubUserFetchException("failed to resolve async calls in time", e);
+        } catch (ExecutionException e) {
+            if (e.getCause() != null) {
+                throw e.getCause();
+            };
+
+            throw e;
+        }
+    }
+
+    private <T> void verifySuccessfulResponse(HttpResponse<T> response) {
+        if (response.statusCode() != 200) {
+            throw new GithubUserFetchException(GITHUB_USER_FETCH_ERROR_TEMPLATE.formatted(response.body()));
+        }
+    }
+}

--- a/src/main/java/com/row49382/service/impl/async/AsyncCachingGithubUserService.java
+++ b/src/main/java/com/row49382/service/impl/async/AsyncCachingGithubUserService.java
@@ -5,7 +5,6 @@ import com.row49382.domain.dto.github.response.GithubUserAggregatedResponse;
 import com.row49382.domain.third_party.github.dto.GithubUserRepoResponse;
 import com.row49382.domain.third_party.github.dto.GithubUserResponse;
 import com.row49382.exception.GithubUserFetchException;
-import com.row49382.exception.JsonDeserializationException;
 import com.row49382.mapper.BiMapper;
 import com.row49382.service.AbstractGithubUserApiService;
 import com.row49382.service.AsyncHandler;
@@ -61,8 +60,8 @@ public class AsyncCachingGithubUserService extends AbstractGithubUserApiService 
             throw new GithubUserFetchException("failed to resolve async calls in time", e);
         } catch (ExecutionException e) {
             if (e.getCause() != null) {
-                throw e.getCause();
-            };
+                throw new Exception(e.getCause());
+            }
 
             throw e;
         }

--- a/src/main/java/com/row49382/service/impl/async/GithubUserAsyncClientHandler.java
+++ b/src/main/java/com/row49382/service/impl/async/GithubUserAsyncClientHandler.java
@@ -1,0 +1,31 @@
+package com.row49382.service.impl.async;
+
+import com.row49382.service.AsyncHandler;
+import com.row49382.service.impl.GitHubUserHttpClientRequestFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.CompletableFuture;
+
+@Component
+public class GithubUserAsyncClientHandler implements AsyncHandler<String> {
+    private final HttpClient client;
+    private final GitHubUserHttpClientRequestFactory requestFactory;
+
+    public GithubUserAsyncClientHandler(
+            HttpClient client,
+            GitHubUserHttpClientRequestFactory requestFactory) {
+        this.client = client;
+        this.requestFactory = requestFactory;
+    }
+
+    @Override
+    @Async
+    public CompletableFuture<HttpResponse<String>> handle(String endpoint) {
+        HttpRequest request = this.requestFactory.buildRequest(endpoint);
+        return client.sendAsync(request, HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.application.name=github-api-service
 github-api-url=https://api.github.com
 github-user-agent=row49382-github-api-service
+handle-async=false

--- a/src/test/java/com/row49382/controller/GithubUserControllerTest.java
+++ b/src/test/java/com/row49382/controller/GithubUserControllerTest.java
@@ -20,7 +20,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(properties = {
         "github-api-url=https://api.github.com",
-        "github-user-agent=test-user-agent"
+        "github-user-agent=test-user-agent",
+        "handle-async=false"
 })
 @AutoConfigureMockMvc
 class GithubUserControllerTest {

--- a/src/test/java/com/row49382/service/impl/AbstractGithubUserApiServiceTest.java
+++ b/src/test/java/com/row49382/service/impl/AbstractGithubUserApiServiceTest.java
@@ -1,0 +1,46 @@
+package com.row49382.service.impl;
+
+import com.row49382.domain.dto.github.response.GithubUserAggregatedResponse;
+import com.row49382.domain.third_party.github.dto.GithubUserRepoResponse;
+import com.row49382.domain.third_party.github.dto.GithubUserResponse;
+import com.row49382.mapper.BiMapper;
+import com.row49382.service.GithubUserApiService;
+import com.row49382.service.JsonService;
+import com.row49382.test_util.ExpectedTestJson;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+abstract class AbstractGithubUserApiServiceTest {
+    protected static final String VALID_USERNAME = "valid";
+    protected static final String INVALID_USERNAME = "invalid";
+    protected static final String GITHUB_USER_ENDPOINT_TEMPLATE = "/users/%s";
+    protected static final String GITHUB_USER_REPO_ENDPOINT_TEMPLATE = GITHUB_USER_ENDPOINT_TEMPLATE + "/repos";
+
+    @Autowired
+    protected JsonService jsonService;
+
+    @Autowired
+    protected BiMapper<GithubUserResponse, List<GithubUserRepoResponse>, GithubUserAggregatedResponse> responseMapper;
+
+    @Autowired
+    protected GitHubUserHttpClientRequestFactory requestFactory;
+
+    @Mock
+    protected HttpClient client;
+
+    protected GithubUserApiService githubUserApiService;
+}

--- a/src/test/java/com/row49382/service/impl/AbstractGithubUserApiServiceTest.java
+++ b/src/test/java/com/row49382/service/impl/AbstractGithubUserApiServiceTest.java
@@ -6,22 +6,12 @@ import com.row49382.domain.third_party.github.dto.GithubUserResponse;
 import com.row49382.mapper.BiMapper;
 import com.row49382.service.GithubUserApiService;
 import com.row49382.service.JsonService;
-import com.row49382.test_util.ExpectedTestJson;
-import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.io.IOException;
 import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
-
-import static org.mockito.Mockito.*;
 
 @SpringBootTest
 abstract class AbstractGithubUserApiServiceTest {

--- a/src/test/java/com/row49382/service/impl/AsyncCachingGithubUserServiceTest.java
+++ b/src/test/java/com/row49382/service/impl/AsyncCachingGithubUserServiceTest.java
@@ -14,16 +14,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.io.IOException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -151,28 +147,27 @@ class AsyncCachingGithubUserServiceTest extends AbstractGithubUserApiServiceTest
         );
     }
 
-    protected CompletableFuture<HttpResponse<String>> mockGithubUserValidResponseAsync() throws InterruptedException, ExecutionException {
+    protected CompletableFuture<HttpResponse<String>> mockGithubUserValidResponseAsync() {
         return this.mockClientResponseAsync(GITHUB_USER_ENDPOINT_TEMPLATE, ExpectedTestJson.GITHUB_USER_RESPONSE_JSON, VALID_USERNAME, 200);
     }
 
-    protected CompletableFuture<HttpResponse<String>> mockGithubUserRepoValidResponseAsync() throws InterruptedException, ExecutionException {
+    protected CompletableFuture<HttpResponse<String>> mockGithubUserRepoValidResponseAsync() {
         return this.mockClientResponseAsync(GITHUB_USER_REPO_ENDPOINT_TEMPLATE, ExpectedTestJson.GITHUB_USER_REPO_LIST_JSON, VALID_USERNAME, 200);
     }
 
-    protected CompletableFuture<HttpResponse<String>> mockGithubUserRepoNotFoundResponseAsync() throws InterruptedException, ExecutionException {
+    protected CompletableFuture<HttpResponse<String>> mockGithubUserRepoNotFoundResponseAsync() {
         return this.mockClientResponseAsync(GITHUB_USER_REPO_ENDPOINT_TEMPLATE, ExpectedTestJson.GITHUB_USER_REPO_LIST_JSON, INVALID_USERNAME, 500);
     }
 
-    protected CompletableFuture<HttpResponse<String>> mockGithubUserNotFoundResponseAsync() throws InterruptedException, ExecutionException {
+    protected CompletableFuture<HttpResponse<String>> mockGithubUserNotFoundResponseAsync() {
         return this.mockClientResponseAsync(GITHUB_USER_ENDPOINT_TEMPLATE, ExpectedTestJson.GITHUB_USER_RESPONSE_JSON, INVALID_USERNAME, 500);
     }
 
-    protected CompletableFuture<HttpResponse<String>> mockGithubUserResponseNotValidJsonResponseAsync() throws InterruptedException, ExecutionException {
+    protected CompletableFuture<HttpResponse<String>> mockGithubUserResponseNotValidJsonResponseAsync() {
         return this.mockClientResponseAsync(GITHUB_USER_ENDPOINT_TEMPLATE, "invalid_json", VALID_USERNAME, 200);
     }
 
-    protected CompletableFuture<HttpResponse<String>> mockClientResponseAsync(String endpoint, String expectedResponse, String username, int statusCode)
-            throws ExecutionException, InterruptedException {
+    protected CompletableFuture<HttpResponse<String>> mockClientResponseAsync(String endpoint, String expectedResponse, String username, int statusCode) {
         HttpResponse<String> response = mock(HttpResponse.class);
         CompletableFuture<HttpResponse<String>> future = CompletableFuture.completedFuture(response);
 

--- a/src/test/java/com/row49382/service/impl/AsyncCachingGithubUserServiceTest.java
+++ b/src/test/java/com/row49382/service/impl/AsyncCachingGithubUserServiceTest.java
@@ -1,0 +1,190 @@
+package com.row49382.service.impl;
+
+import com.row49382.domain.dto.github.response.GithubUserAggregatedResponse;
+import com.row49382.domain.dto.github.response.GithubUserRepositoryResponse;
+import com.row49382.exception.GithubUserFetchException;
+import com.row49382.exception.JsonDeserializationException;
+import com.row49382.service.AsyncHandler;
+import com.row49382.service.impl.async.AsyncCachingGithubUserService;
+import com.row49382.service.impl.async.GithubUserAsyncClientHandler;
+import com.row49382.test_util.ExpectedTestJson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.IOException;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+class AsyncCachingGithubUserServiceTest extends AbstractGithubUserApiServiceTest {
+    @BeforeEach
+    public void setup() {
+        AsyncHandler<String> asyncHandler = new GithubUserAsyncClientHandler(this.client, this.requestFactory);
+        this.githubUserApiService =
+                new AsyncCachingGithubUserService(this.client, this.jsonService, this.responseMapper, this.requestFactory, asyncHandler);
+    }
+    @Test
+    void verifyGithubUsernameFetchSuccessAsync() throws Throwable {
+        CompletableFuture<HttpResponse<String>> githubUserResponse = this.mockGithubUserValidResponseAsync();
+        CompletableFuture<HttpResponse<String>> githubUserRepoResponse = this.mockGithubUserRepoValidResponseAsync();
+
+        GithubUserAggregatedResponse githubUserAggregatedResponse =
+                this.githubUserApiService.fetchByUsername(VALID_USERNAME);
+
+        HttpResponse<String> expectedUserResponse = githubUserResponse.get();
+        HttpResponse<String> expectedUserRepoResponse = githubUserRepoResponse.get();
+
+        verify(expectedUserResponse).statusCode();
+        verify(expectedUserResponse).body();
+        verify(expectedUserRepoResponse).statusCode();
+        verify(expectedUserRepoResponse).body();
+        verify(this.client, times(2)).sendAsync(any(HttpRequest.class), eq(HttpResponse.BodyHandlers.ofString()));
+
+        assertNotNull(githubUserAggregatedResponse);
+        assertEquals("octocat", githubUserAggregatedResponse.getUsername());
+        assertEquals("https://avatars.githubusercontent.com/u/583231?v=4", githubUserAggregatedResponse.getAvatar());
+        assertEquals("https://github.com/octocat", githubUserAggregatedResponse.getUrl());
+        assertEquals("The Octocat", githubUserAggregatedResponse.getDisplayName());
+        assertEquals("San Francisco", githubUserAggregatedResponse.getGeoLocation());
+        assertEquals("2011-01-25T18:44:36Z", githubUserAggregatedResponse.getCreatedAt().toInstant().toString());
+        assertNull(githubUserAggregatedResponse.getEmail());
+
+        GithubUserRepositoryResponse firstRepo = githubUserAggregatedResponse.getRepos().get(0);
+        GithubUserRepositoryResponse secondRepo = githubUserAggregatedResponse.getRepos().get(1);
+
+        assertNotNull(firstRepo);
+        assertEquals("boysenberry-repo-1", firstRepo.getName());
+        assertEquals("https://github.com/octocat/boysenberry-repo-1", firstRepo.getUrl());
+
+        assertNotNull(secondRepo);
+        assertEquals("git-consortium", secondRepo.getName());
+        assertEquals("https://github.com/octocat/git-consortium", secondRepo.getUrl());
+    }
+
+    @Test
+    void verifyWhenGithubUsernameNotFoundThenFetchExceptionIsThrownAsync() throws InterruptedException, ExecutionException {
+        CompletableFuture<HttpResponse<String>> githubUserResponse =
+                this.mockGithubUserNotFoundResponseAsync();
+        CompletableFuture<HttpResponse<String>> githubUserRepoResponse =
+                this.mockGithubUserRepoNotFoundResponseAsync();
+
+        assertThrows(
+                GithubUserFetchException.class,
+                () -> this.githubUserApiService.fetchByUsername(INVALID_USERNAME));
+
+        HttpResponse<String> expectedUserResponse = githubUserResponse.get();
+        HttpResponse<String> expectedUserRepoResponse = githubUserRepoResponse.get();
+
+        verify(expectedUserResponse).statusCode();
+        verify(expectedUserResponse).body();
+        verify(expectedUserRepoResponse, never()).statusCode();
+        verify(expectedUserRepoResponse, never()).body();
+        verify(this.client, times(2)).sendAsync(any(HttpRequest.class), eq(HttpResponse.BodyHandlers.ofString()));
+    }
+
+    @Test
+    void verifyWhenGithubUsernameResponseInvalidJsonThenDeserializationExceptionIsThrownAsync() throws InterruptedException, ExecutionException {
+        CompletableFuture<HttpResponse<String>> githubUserResponse =
+                this.mockGithubUserResponseNotValidJsonResponseAsync();
+        CompletableFuture<HttpResponse<String>> githubUserRepoResponse =
+                this.mockGithubUserRepoValidResponseAsync();
+
+        assertThrows(
+                JsonDeserializationException.class,
+                () -> this.githubUserApiService.fetchByUsername(VALID_USERNAME));
+
+        HttpResponse<String> expectedUserResponse = githubUserResponse.get();
+        HttpResponse<String> expectedUserRepoResponse = githubUserRepoResponse.get();
+
+        verify(expectedUserResponse).statusCode();
+        verify(expectedUserResponse).body();
+        verify(expectedUserRepoResponse).statusCode();
+        verify(expectedUserRepoResponse, never()).body();
+        verify(this.client, times(2)).sendAsync(any(HttpRequest.class), eq(HttpResponse.BodyHandlers.ofString()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getFutureExceptions")
+    void verifyWhenHttpClientThrowsExceptionThenFetchExceptionIsThrownAsync(Throwable futureException) throws InterruptedException, ExecutionException {
+        CompletableFuture<HttpResponse<String>> future = mock(CompletableFuture.class);
+        lenient().when(future.thenCompose(any(Function.class))).thenReturn(future);
+        lenient().when(future.thenApply(any(Function.class))).thenReturn(future);
+
+        when(this.client.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(future);
+
+        when(future.get()).thenThrow(futureException);
+
+        assertThrows(
+                GithubUserFetchException.class,
+                () -> this.githubUserApiService.fetchByUsername("octocat"));
+
+        verify(future).get();
+        verify(this.client, times(2)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+    }
+
+    private static Stream<Arguments> getFutureExceptions() {
+        return Stream.of(
+                Arguments.of(new InterruptedException()),
+                Arguments.of(new ExecutionException(new GithubUserFetchException("")))
+        );
+    }
+
+    protected CompletableFuture<HttpResponse<String>> mockGithubUserValidResponseAsync() throws InterruptedException, ExecutionException {
+        return this.mockClientResponseAsync(GITHUB_USER_ENDPOINT_TEMPLATE, ExpectedTestJson.GITHUB_USER_RESPONSE_JSON, VALID_USERNAME, 200);
+    }
+
+    protected CompletableFuture<HttpResponse<String>> mockGithubUserRepoValidResponseAsync() throws InterruptedException, ExecutionException {
+        return this.mockClientResponseAsync(GITHUB_USER_REPO_ENDPOINT_TEMPLATE, ExpectedTestJson.GITHUB_USER_REPO_LIST_JSON, VALID_USERNAME, 200);
+    }
+
+    protected CompletableFuture<HttpResponse<String>> mockGithubUserRepoNotFoundResponseAsync() throws InterruptedException, ExecutionException {
+        return this.mockClientResponseAsync(GITHUB_USER_REPO_ENDPOINT_TEMPLATE, ExpectedTestJson.GITHUB_USER_REPO_LIST_JSON, INVALID_USERNAME, 500);
+    }
+
+    protected CompletableFuture<HttpResponse<String>> mockGithubUserNotFoundResponseAsync() throws InterruptedException, ExecutionException {
+        return this.mockClientResponseAsync(GITHUB_USER_ENDPOINT_TEMPLATE, ExpectedTestJson.GITHUB_USER_RESPONSE_JSON, INVALID_USERNAME, 500);
+    }
+
+    protected CompletableFuture<HttpResponse<String>> mockGithubUserResponseNotValidJsonResponseAsync() throws InterruptedException, ExecutionException {
+        return this.mockClientResponseAsync(GITHUB_USER_ENDPOINT_TEMPLATE, "invalid_json", VALID_USERNAME, 200);
+    }
+
+    protected CompletableFuture<HttpResponse<String>> mockClientResponseAsync(String endpoint, String expectedResponse, String username, int statusCode)
+            throws ExecutionException, InterruptedException {
+        HttpResponse<String> response = mock(HttpResponse.class);
+        CompletableFuture<HttpResponse<String>> future = CompletableFuture.completedFuture(response);
+
+        lenient().when(response.statusCode()).thenReturn(statusCode);
+        lenient().when(response.body()).thenReturn(expectedResponse);
+
+        HttpRequest githubUserRequest =
+                this.requestFactory.buildRequest(endpoint.formatted(username));
+
+        when(this.client.sendAsync(githubUserRequest, HttpResponse.BodyHandlers.ofString()))
+                .thenReturn(future);
+
+        return future;
+    }
+}

--- a/src/test/java/com/row49382/service/impl/CachingGithubUserApiServiceTest.java
+++ b/src/test/java/com/row49382/service/impl/CachingGithubUserApiServiceTest.java
@@ -16,8 +16,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.io.IOException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;


### PR DESCRIPTION
* Adding async functionality to the github api user and repository API calls
* Added configuration to determine if the sync or async implementation is used
* Refactored implementation to move shared functionality out
* Made checked exceptions Runtime Exceptions so they don't need to be caught and rethrown in the `thenApply` method
* Added Tests to verify new functionality